### PR TITLE
Use double quotes in translations

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -34,7 +34,7 @@ fof-webhooks:
 
   admin:
     errors:
-      service_not_found: The service '{service}' cannot be found.
+      service_not_found: 'The service "{service}" cannot be found.'
       url_invalid: URL is not valid for selected service.
       tag_invalid: This webhook is restricted to an invalid tag. The restriction will not apply. Make sure this is intended.
 


### PR DESCRIPTION
See https://github.com/flarum/framework/issues/3702

I think it is safer to use double quote until this issue is clarified/fixed.