### PR TITLE
Allow selecting multiple tags per webhook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     }
   ],
   "require": {
-    "flarum/core": "^1.2.0",
+    "flarum/core": "^1.7.0",
     "guzzlehttp/guzzle": "7.*",
     "ssnepenthe/color-utils": "^0.4.2",
     "html2text/html2text": "^4.3.1",

--- a/extend.php
+++ b/extend.php
@@ -41,14 +41,6 @@ return [
     (new Extend\ApiSerializer(ForumSerializer::class))
         ->hasMany('webhooks', WebhookSerializer::class),
 
-    (new Extend\ApiController(ShowForumController::class))
-        ->addInclude('webhooks')
-        ->prepareDataForSerialization(function (ShowForumController $controller, &$data, ServerRequestInterface $request) {
-            $actor = $request->getAttribute('actor');
-
-            $data['webhooks'] = $actor->isAdmin() ? Webhook::all() : [];
-        }),
-
     (new Extend\Event())
         ->subscribe(Listener\TriggerListener::class),
 ];

--- a/extend.php
+++ b/extend.php
@@ -11,15 +11,12 @@
 
 namespace FoF\Webhooks;
 
-use Flarum\Api\Controller\ShowForumController;
 use Flarum\Api\Serializer\ForumSerializer;
 use Flarum\Extend;
 use Flarum\Frontend\Document;
 use FoF\Webhooks\Adapters\Adapters;
 use FoF\Webhooks\Api\Serializer\WebhookSerializer;
 use FoF\Webhooks\Listener\TriggerListener;
-use FoF\Webhooks\Models\Webhook;
-use Psr\Http\Message\ServerRequestInterface;
 
 return [
     (new Extend\Frontend('admin'))

--- a/js/package.json
+++ b/js/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "webpack --mode production",
     "dev": "webpack --mode development --watch",
-    "lint": "prettier --write src"
+    "format": "prettier --write src"
   },
   "devDependencies": {
     "flarum-tsconfig": "^1.0.2",

--- a/js/src/admin/components/SettingsListItem.js
+++ b/js/src/admin/components/SettingsListItem.js
@@ -29,6 +29,8 @@ export default class SettingsListItem extends Component {
 
   view() {
     const { webhook, services } = this;
+    const isTagsEnabled = app.initializers.has('flarum-tags');
+    const tags = webhook.tags().filter(Boolean);
 
     const service = webhook.service();
     const errors = [webhook.error && webhook.error()];
@@ -37,11 +39,11 @@ export default class SettingsListItem extends Component {
       errors.push(app.translator.trans('fof-webhooks.admin.errors.service_not_found', { service }));
     } else if (!webhook.isValid()) {
       errors.push(app.translator.trans('fof-webhooks.admin.errors.url_invalid'));
-    } else if (webhook.tags().filter(Boolean).length !== webhook.attribute('tag_id').length) {
+    } else if (!isTagsEnabled && webhook.tags().length !== 0) {
+      errors.push(app.translator.trans('fof-webhooks.admin.errors.tag_disabled'));
+    } else if (tags.length !== webhook.attribute('tag_id').length) {
       errors.push(app.translator.trans('fof-webhooks.admin.errors.tag_invalid'));
     }
-
-    const tags = webhook.tags();
 
     const changeTags = () =>
       app.modal.show(TagSelectionModal, {
@@ -63,11 +65,12 @@ export default class SettingsListItem extends Component {
             placeholder={app.translator.trans('fof-webhooks.admin.settings.help.url')}
           />
 
-          {tags.length ? (
-            tagsLabel(tags, { onclick: changeTags })
-          ) : (
-            <span className="tagsLabel">app.translator.trans('fof-webhooks.admin.settings.item.tag_any_label')</span>
-          )}
+          {isTagsEnabled &&
+            (tags.length ? (
+              tagsLabel(tags, { onclick: changeTags })
+            ) : (
+              <span className="tagsLabel">app.translator.trans('fof-webhooks.admin.settings.item.tag_any_label')</span>
+            ))}
 
           <Button
             type="button"

--- a/js/src/admin/components/WebhooksPage.js
+++ b/js/src/admin/components/WebhooksPage.js
@@ -64,6 +64,7 @@ export default class WebhooksPage extends ExtensionPage {
 
           <form>
             <p className="helpText">{app.translator.trans('fof-webhooks.admin.settings.help.general')}</p>
+            {this.isTagsEnabled() && <p className="helpText">{app.translator.trans('fof-webhooks.admin.settings.help.tags')}</p>}
             <fieldset>
               <div className="Webhooks--Container">
                 {webhooks.map((webhook) => (

--- a/js/src/admin/components/WebhooksPage.js
+++ b/js/src/admin/components/WebhooksPage.js
@@ -24,25 +24,22 @@ export default class WebhooksPage extends ExtensionPage {
       loading: Stream(false),
     };
 
-    this.loadingTags = this.isTagsEnabled();
+    this.loadingData = Stream(true);
   }
 
   oncreate(vnode) {
     super.oncreate(vnode);
 
-    if (this.loadingTags) {
-      app.store.find('tags').then(() => {
-        this.loadingTags = false;
-
-        m.redraw();
-      });
-    }
+    Promise.all([app.store.find('fof/webhooks'), this.isTagsEnabled() && app.store.find('tags')]).then(() => {
+      this.loadingData(false);
+      m.redraw();
+    });
   }
 
   content() {
     const webhooks = app.store.all('webhooks');
 
-    if (this.loadingTags) {
+    if (this.loadingData()) {
       return <LoadingIndicator />;
     }
 

--- a/js/src/admin/models/Webhook.js
+++ b/js/src/admin/models/Webhook.js
@@ -9,7 +9,7 @@ export default class Webhook extends Model {
   error = Model.attribute('error');
   events = Model.attribute('events');
 
-  tagId = Model.attribute('tag_id');
+  tagIds = Model.attribute('tag_id');
 
   groupId = Model.attribute('group_id');
   extraText = Model.attribute('extra_text');
@@ -23,7 +23,7 @@ export default class Webhook extends Model {
     return `/fof/webhooks${this.exists ? `/${this.data.id}` : ''}`;
   }
 
-  tag() {
-    return app.store.getById('tags', this.tagId());
+  tags() {
+    return this.tagIds().map((id) => app.store.getById('tags', id));
   }
 }

--- a/migrations/2023_06_07_change_tag_id_to_json.php
+++ b/migrations/2023_06_07_change_tag_id_to_json.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of fof/webhooks.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('webhooks', function (Blueprint $table) {
+            $table->json('tag_id')->change();
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('webhooks', function (Blueprint $table) {
+            $table->unsignedInteger('tag_id')->change();
+        });
+    },
+];

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -10,7 +10,13 @@
     flex-direction: row;
     flex-basis: fit-content;
 
-    > .Select, > button, > input, > div {
+    .TagsLabel {
+      flex-grow: 1;
+      white-space: nowrap;
+      align-self: center;
+    }
+
+    > .Select, > button, > input, > div, .TagsLabel {
       margin: 0 5px;
     }
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -38,6 +38,7 @@ fof-webhooks:
       service_not_found: 'The service "{service}" cannot be found.'
       url_invalid: URL is not valid for selected service.
       tag_invalid: This webhook is restricted to an invalid tag. The restriction will not apply. Make sure this is intended.
+      tag_disabled: This webhook had a tag restriction configured. The Tags extension is disabled. The restriction will not apply. Make sure this is intended.
 
     nav:
       desc: Customizable outgoing webhooks for your forum.
@@ -51,6 +52,7 @@ fof-webhooks:
       help:
         disabled: This webhook is disabled because it doesn't have any events enabled.
         general: Here you can add, edit, and remove webhooks from your forum.
+        tags: You can restrict webhooks to specific tags. If you select any tags, the webhook will only be fired if the event is triggered on a resource that has any of the selected tags.
         url: The webhook's endpoint to be executed
 
       modal:

--- a/src/Action.php
+++ b/src/Action.php
@@ -49,7 +49,7 @@ abstract class Action
 
     /**
      * @param Webhook $webhook
-     * @param $event
+     * @param         $event
      *
      * @return Response|null
      *
@@ -61,7 +61,7 @@ abstract class Action
     }
 
     /**
-     * @param $event
+     * @param         $event
      * @param Webhook $webhook
      *
      * @return bool
@@ -73,7 +73,7 @@ abstract class Action
 
     /**
      * @param string $id
-     * @param $param1
+     * @param        $param1
      *
      * @return string
      */

--- a/src/Actions/Discussion/Action.php
+++ b/src/Actions/Discussion/Action.php
@@ -30,10 +30,10 @@ abstract class Action extends \FoF\Webhooks\Action
             return true;
         }
 
-        $tag = $webhook->tag;
+        $tagIds = $webhook->tag_id;
         $tagsIsEnabled = resolve(ExtensionManager::class)->isEnabled('flarum-tags');
 
-        if ($tag && $tagsIsEnabled && !$discussion->tags()->where('id', $tag->id)->exists()) {
+        if (!empty($tagIds) && $tagsIsEnabled && !$discussion->tags()->whereIn('id', $webhook->tag_id)->exists()) {
             return true;
         }
 

--- a/src/Actions/Post/Action.php
+++ b/src/Actions/Post/Action.php
@@ -24,10 +24,10 @@ abstract class Action extends \FoF\Webhooks\Action
         }
 
         $discussion = $event->post->discussion;
-        $tag = $webhook->tag;
+        $tagIds = $webhook->tag_id;
         $tagsIsEnabled = resolve(ExtensionManager::class)->isEnabled('flarum-tags');
 
-        if ($discussion && $tag && $tagsIsEnabled && !$discussion->tags()->where('id', $tag->id)->exists()) {
+        if ($discussion && !empty($tagIds) && $tagsIsEnabled && !$discussion->tags()->whereIn('id', $tagIds)->exists()) {
             return true;
         }
 

--- a/src/Actions/Post/Approved.php
+++ b/src/Actions/Post/Approved.php
@@ -19,7 +19,7 @@ class Approved extends Posted
     const EVENT = \Flarum\Approval\Event\PostWasApproved::class;
 
     /**
-     * @param Webhook                   $webhook
+     * @param Webhook                                $webhook
      * @param \Flarum\Approval\Event\PostWasApproved $event
      *
      * @return Response

--- a/src/Command/UpdateWebhookHandler.php
+++ b/src/Command/UpdateWebhookHandler.php
@@ -78,13 +78,9 @@ class UpdateWebhookHandler
         }
 
         if (Arr::has($data, 'attributes.tag_id') && class_exists(Tag::class)) {
-            $tagId = Arr::get($data, 'attributes.tag_id');
+            $tagIds = Arr::get($data, 'attributes.tag_id');
 
-            if (is_numeric($tagId) && Tag::query()->where('id', $tagId)->exists()) {
-                $webhook->tag_id = $tagId;
-            } else {
-                $webhook->tag_id = null;
-            }
+            $webhook->tag_id = $tagIds;
         }
 
         if (isset($usePlainText)) {

--- a/src/Models/Webhook.php
+++ b/src/Models/Webhook.php
@@ -72,7 +72,9 @@ class Webhook extends AbstractModel
 
     public function tags()
     {
-        if (!class_exists(Tag::class)) return null;
+        if (!class_exists(Tag::class)) {
+            return null;
+        }
 
         return Tag::whereIn('id', $this->tag_id)->get();
     }
@@ -86,8 +88,11 @@ class Webhook extends AbstractModel
 
     public function getTagIdAttribute($value): array
     {
-        if (is_numeric($value)) return [$value];
-        else if (is_array($value)) return $value;
+        if (is_numeric($value)) {
+            return [$value];
+        } elseif (is_array($value)) {
+            return $value;
+        }
 
         return json_decode($value) ?? [];
     }

--- a/src/Models/Webhook.php
+++ b/src/Models/Webhook.php
@@ -70,9 +70,11 @@ class Webhook extends AbstractModel
         return $this->belongsTo(Group::class);
     }
 
-    public function tag(): BelongsTo
+    public function tags()
     {
-        return $this->belongsTo(Tag::class);
+        if (!class_exists(Tag::class)) return null;
+
+        return Tag::whereIn('id', $this->tag_id)->get();
     }
 
     public function asGuest(): bool
@@ -80,5 +82,13 @@ class Webhook extends AbstractModel
         $group = $this->group;
 
         return !$group || $group->id == Group::GUEST_ID;
+    }
+
+    public function getTagIdAttribute($value): array
+    {
+        if (is_numeric($value)) return [$value];
+        else if (is_array($value)) return $value;
+
+        return json_decode($value) ?? [];
     }
 }

--- a/src/Validator/WebhookValidator.php
+++ b/src/Validator/WebhookValidator.php
@@ -34,6 +34,6 @@ class WebhookValidator extends AbstractValidator
             'nullable',
             'array',
             'exists:tags,id',
-        ]
+        ],
     ];
 }

--- a/src/Validator/WebhookValidator.php
+++ b/src/Validator/WebhookValidator.php
@@ -30,5 +30,10 @@ class WebhookValidator extends AbstractValidator
             'int',
             'in:1,2',
         ],
+        'tag_id' => [
+            'nullable',
+            'array',
+            'exists:tags,id',
+        ]
     ];
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #33**

**Changes proposed in this pull request:**
- Convert `tag_id` column into JSON array of IDs
- Use tag selection modal in core

**Reviewers should focus on:**
Properly works with migrating from previous version with values in columns? Seems to work for me.

**Screenshot**
![image](https://github.com/FriendsOfFlarum/webhooks/assets/6401250/ac531aab-33fc-47bd-8cf3-1c458f590557)
![image](https://github.com/FriendsOfFlarum/webhooks/assets/6401250/bfc29622-65d2-472a-9724-c95069401377)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
