### PR TITLE
Fix error when migrating with existing `webhooks.tag_id` foreign

### DIFF
--- a/migrations/2023_06_07_000000_remove_tag_id_constraint.php
+++ b/migrations/2023_06_07_000000_remove_tag_id_constraint.php
@@ -34,5 +34,5 @@ return [
     },
     'down' => static function (Builder $schema) {
         //
-    }
+    },
 ];

--- a/migrations/2023_06_07_000000_remove_tag_id_constraint.php
+++ b/migrations/2023_06_07_000000_remove_tag_id_constraint.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of fof/webhooks.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+// Removes foreign key constraint for tag_id column that existed in previous versions of the extension.
+// Deleting the index is also necessary to prevent errors when changing the column type to JSON in the next migration.
+return [
+    'up' => static function (Builder $schema) {
+        $schema->table('webhooks', function (Blueprint $table) use ($schema) {
+            $indexes = $schema->getConnection()->getDoctrineSchemaManager()->listTableIndexes($table->getTable());
+
+            /**
+             * @var \Doctrine\DBAL\Schema\Index $index
+             */
+            $index = collect($indexes)->first(function ($index) {
+                return in_array('tag_id', $index->getColumns(), true);
+            });
+
+            if ($index) {
+                $table->dropForeign(['tag_id']);
+                $table->dropIndex($index->getName());
+            }
+        });
+    },
+    'down' => static function (Builder $schema) {
+        //
+    }
+];


### PR DESCRIPTION
**Fixes #64**

**Changes proposed in this pull request:**
- Create migration that removes both foreign key & index of `tag_id` column

**Reviewers should focus on:**
I think this *should* work with prefixes... but not entirely sure. Haven't tested that aspect.

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [X] Backend changes: tests are green (run `composer test`).
